### PR TITLE
feat: Allow specifying start and end frames for data preparation

### DIFF
--- a/script/my_convert_frames.py
+++ b/script/my_convert_frames.py
@@ -33,7 +33,6 @@ args = parser.parse_args()
 colmap_command = '"{}"'.format(args.colmap_executable) if len(args.colmap_executable) > 0 else "colmap"
 magick_command = '"{}"'.format(args.magick_executable) if len(args.magick_executable) > 0 else "magick"
 use_gpu = 1 if not args.no_gpu else 0
-endframe = args.endframe
 
 # for id in range(1,args.last_frame_id+1):
 def process(item):
@@ -98,7 +97,8 @@ def process(item):
             #     exit(exit_code)
 p = mp.Pool(100)
 res = []
-for i in tqdm(range(1,endframe)):
+# Since colmap_0 is processed separately, this loop should start from 1 to the total number of frames.
+for i in tqdm(range(1, args.endframe)):
     # print(i)
     item = f"colmap_{i}"
     res.append(p.apply_async(process, args=(item,)))

--- a/script/pre_input.py
+++ b/script/pre_input.py
@@ -60,26 +60,22 @@ def extractframes(videopath):
 
 
 
-def preparecolmapdynerf(folder, offset=0):
-    print(offset)
+def preparecolmapdynerf(folder, offset=0, output_idx=0):
+    print(f"Processing frame {offset} to output index {output_idx}")
     folderlist = glob.glob(folder + "cam**/")
-    imagelist = []
-    savedir = os.path.join(folder, "colmap_" + str(offset))
+    savedir = os.path.join(folder, "colmap_" + str(output_idx))
     if not os.path.exists(savedir):
         os.mkdir(savedir)
     savedir = os.path.join(savedir, "input")
     if not os.path.exists(savedir):
         os.mkdir(savedir)
-    for folder in folderlist :
-        imagepath = os.path.join(folder, str(offset) + ".png")
-        imagesavepath = os.path.join(savedir, folder.split("/")[-2] + ".png")
-
-        shutil.copy(imagepath, imagesavepath)
-
-
-    
-
-
+    for folder_item in folderlist :
+        imagepath = os.path.join(folder_item, str(offset) + ".png")
+        imagesavepath = os.path.join(savedir, folder_item.split("/")[-2] + ".png")
+        if os.path.exists(imagepath):
+            shutil.copy(imagepath, imagesavepath)
+        else:
+            print(f"Warning: Source image not found {imagepath}")
 
 if __name__ == "__main__" :
     parser = argparse.ArgumentParser()
@@ -122,8 +118,8 @@ if __name__ == "__main__" :
     # # ## step2 prepare colmap input 
     res = []
     p = mp.Pool(100)
-    for offset in range(startframe, endframe):
-        res.append(p.apply_async(preparecolmapdynerf, args=(videopath,offset)))
+    for i, offset in enumerate(range(startframe, endframe)):
+        res.append(p.apply_async(preparecolmapdynerf, args=(videopath, offset, i)))
     p.close()
     p.join()
     print("prepare input down")

--- a/script/pre_test_data.sh
+++ b/script/pre_test_data.sh
@@ -1,20 +1,38 @@
 #!/bin/bash
 
-# Check if the user provided a video path as an argument
+# Default values
+START_FRAME=0
+END_FRAME=60
+
+# Check if the user provided a video path as an argument. The first argument must be the videopath.
 if [ -z "$1" ]; then
-  echo "Usage: $0 <videopath>"
+  echo "Usage: $0 <videopath> [--start_frame <start>] [--end_frame <end>]"
   exit 1
 fi
+VIDEOPATH="$1"
+shift # consume videopath argument
 
-# Assign the first argument to the videopath variable
-videopath="$1"
+# Parse optional arguments for start and end frames
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --start_frame) START_FRAME="$2"; shift ;;
+        --end_frame) END_FRAME="$2"; shift ;;
+        *) echo "Unknown parameter passed: $1"; exit 1 ;;
+    esac
+    shift
+done
 
-# Run the Python scripts with the provided path
+# Run the Python scripts with the provided path and frames
 echo "pre_input.py"
-python pre_input.py --videopath "$videopath" --endframe 60
+python pre_input.py --videopath "$VIDEOPATH" --startframe "$START_FRAME" --endframe "$END_FRAME"
+
 echo "my_convert.py"
-python my_convert.py -s "$videopath/colmap_0"
+python my_convert.py -s "$VIDEOPATH/colmap_0"
+
 echo "my_copy_cams.py"
-python my_copy_cams.py --source "$videopath/colmap_0" --scene "$videopath"
+python my_copy_cams.py --source "$VIDEOPATH/colmap_0" --scene "$VIDEOPATH"
+
 echo "my_convert_frames.py"
-python my_convert_frames.py -s "$videopath"  --endframe 60
+# Calculate the number of frames to process based on the interval
+NUM_FRAMES=$((END_FRAME - START_FRAME))
+python my_convert_frames.py -s "$VIDEOPATH" --endframe "$NUM_FRAMES"


### PR DESCRIPTION
This commit introduces the ability to specify a start and end frame when running the `pre_test_data.sh` script.

The following changes have been made:

- `script/pre_test_data.sh`: Modified to accept `--start_frame` and `--end_frame` command-line arguments. It now calculates the total number of frames to process and passes the correct parameters to the downstream Python scripts.
- `script/pre_input.py`: Updated to handle the specified frame range. It now remaps the output directories to be zero-indexed (e.g., `colmap_0`, `colmap_1`, ...) regardless of the input start frame, fulfilling a key requirement.
- `script/my_convert_frames.py`: Cleaned up to remove an unnecessary `--startframe` argument and ensure its processing loop correctly handles the number of frames passed from the main shell script.

This allows for more flexible data preparation by enabling users to process specific segments of a video.